### PR TITLE
feat(state): Split `Blob` into blob parts and send it to internal message queue

### DIFF
--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1273,16 +1273,20 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 		cs.Logger.Error("failed flushing WAL to disk")
 	}
 
-	var propBlobID types.BlobID
+	var (
+		propBlobID types.BlobID
+		blobParts  *types.PartSet
+	)
+	// Not all blocks have a corresponding blob. If that's the case, we don't create
+	// blob parts and we don't set the blob ID.
 	if !blob.IsNil() {
-		blobParts := types.NewPartSetFromData(blob, types.BlobPartSizeBytes)
+		blobParts = types.NewPartSetFromData(blob, types.BlobPartSizeBytes)
 		propBlobID = types.BlobID{
 			Hash:          blob.Hash(),
 			PartSetHeader: blobParts.Header(),
 		}
 	}
 
-	// Make proposal
 	var (
 		propBlockID = types.BlockID{
 			Hash:          block.Hash(),
@@ -1302,7 +1306,7 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 	if err == nil {
 		proposal.Signature = protoProposal.Signature
 
-		// send proposal and block parts on internal proposalMsg queue
+		// send proposal, block parts, and blob parts on internal proposalMsg queue
 		proposalMsg := msgInfo{
 			Msg:         &ProposalMessage{proposal},
 			PeerID:      "",
@@ -1310,9 +1314,9 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 		}
 		cs.sendInternalMessage(proposalMsg)
 
-		for i := 0; i < int(blockParts.Total()); i++ {
+		for i := range blockParts.Total() {
 			var (
-				part       = blockParts.GetPart(i)
+				part       = blockParts.GetPart(int(i))
 				blkPartMsg = msgInfo{
 					Msg:         &BlockPartMessage{cs.Height, cs.Round, part},
 					PeerID:      "",
@@ -1320,6 +1324,23 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 				}
 			)
 			cs.sendInternalMessage(blkPartMsg)
+		}
+
+		// Recall that not all blocks have a corresponding blob. Therefore, we might
+		// have not initialized the blobParts pointer a few lines above. Obviously,
+		// if blobParts is nil, we have nothing to send.
+		if blobParts != nil {
+			for i := range blobParts.Total() {
+				var (
+					part        = blobParts.GetPart(int(i))
+					blobPartMsg = msgInfo{
+						Msg:         &BlobPartMessage{cs.Height, cs.Round, part},
+						PeerID:      "",
+						ReceiveTime: time.Time{},
+					}
+				)
+				cs.sendInternalMessage(blobPartMsg)
+			}
 		}
 
 		cs.Logger.Debug(

--- a/internal/consensus/state.go
+++ b/internal/consensus/state.go
@@ -1259,6 +1259,7 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 		}
 
 		cs.metrics.ProposalCreateCount.Add(1)
+
 		blockParts, err = block.MakePartSet(types.BlockPartSizeBytes)
 		if err != nil {
 			cs.Logger.Error("unable to create proposal block part set", "error", err)
@@ -1272,11 +1273,17 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 		cs.Logger.Error("failed flushing WAL to disk")
 	}
 
-	// Make proposal
+	var propBlobID types.BlobID
+	if !blob.IsNil() {
+		blobParts := types.NewPartSetFromData(blob, types.BlobPartSizeBytes)
+		propBlobID = types.BlobID{
+			Hash:          blob.Hash(),
+			PartSetHeader: blobParts.Header(),
+		}
+	}
 
+	// Make proposal
 	var (
-		// TODO: create blob parts, BlobID, send blob parts.
-		_           = blob
 		propBlockID = types.BlockID{
 			Hash:          block.Hash(),
 			PartSetHeader: blockParts.Header(),
@@ -1287,7 +1294,7 @@ func (cs *State) defaultDecideProposal(height int64, round int32) {
 			cs.ValidRound,
 			propBlockID,
 			block.Header.Time,
-			types.BlobID{}, // TODO: add part set
+			propBlobID,
 		)
 		protoProposal = proposal.ToProto()
 	)

--- a/state/indexer/block/kv/kv_test.go
+++ b/state/indexer/block/kv/kv_test.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	db "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"

--- a/state/pruner_test.go
+++ b/state/pruner_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	db "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"

--- a/state/txindex/kv/kv_test.go
+++ b/state/txindex/kv/kv_test.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 
 	db "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"

--- a/types/blob_test.go
+++ b/types/blob_test.go
@@ -3,11 +3,12 @@ package types
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	"github.com/cometbft/cometbft/libs/bytes"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBlobIDValidateBasic(t *testing.T) {

--- a/types/canonical_test.go
+++ b/types/canonical_test.go
@@ -4,10 +4,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	cmtproto "github.com/cometbft/cometbft/api/cometbft/types/v1"
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	cmtrand "github.com/cometbft/cometbft/internal/rand"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCanonicalizeBlockID(t *testing.T) {

--- a/types/params.go
+++ b/types/params.go
@@ -26,7 +26,7 @@ const (
 	MaxBlockPartsCount = (MaxBlockSizeBytes / BlockPartSizeBytes) + 1
 
 	// MaxBlobSyzeBytes is the maximum permitted size of a blob.
-	MaxBlobSizeBytes = 800 * 1024 // 800KB
+	MaxBlobSizeBytes = 800 * 1024 // 800kB
 
 	// BlobPartSizeBytes is the size of one blob part.
 	BlobPartSizeBytes uint32 = 65536 // 64kB

--- a/types/params.go
+++ b/types/params.go
@@ -25,6 +25,15 @@ const (
 	// MaxBlockPartsCount is the maximum number of block parts.
 	MaxBlockPartsCount = (MaxBlockSizeBytes / BlockPartSizeBytes) + 1
 
+	// MaxBlobSyzeBytes is the maximum permitted size of a blob.
+	MaxBlobSizeBytes = 800 * 1024 // 800KB
+
+	// BlobPartSizeBytes is the size of one blob part.
+	BlobPartSizeBytes uint32 = 65536 // 64kB
+
+	// MaxBlobPartsCount defines the maximum number of blob parts.
+	MaxBlobPartsCount = (MaxBlobSizeBytes / BlobPartSizeBytes) + 1
+
 	ABCIPubKeyTypeEd25519   = ed25519.KeyType
 	ABCIPubKeyTypeSecp256k1 = secp256k1.KeyType
 	ABCIPubKeyTypeBls12381  = bls12381.KeyType


### PR DESCRIPTION
Part of the work of https://github.com/berachain/cometbft/pull/26.

### Context
A blob in a CometBFT blob's size can be between 128-800KB. To prevent sending big messages through the network, we want to split them into smaller ones and have peers reassemble the original message from its parts.

### Changes
This PR splits a non-nil blob into blob parts and sends them through the internal message queue so that the consensus state/reactor can process them. A blob part's size is at most 64KB. 

Note: the PR includes changes to unrelated files to address some complaints of the linter (i.e., they are not behavioral changes). The work relevant to this pr is in `internal/consensus/state.go` and `types/params.go`.