### PR TITLE
feat(state): Add blob-related fields to `PeerRoundState`

### DIFF
--- a/internal/consensus/reactor_test.go
+++ b/internal/consensus/reactor_test.go
@@ -1125,16 +1125,19 @@ func TestVoteSetBitsMessageValidateBasic(t *testing.T) {
 func TestMarshalJSONPeerState(t *testing.T) {
 	ps := NewPeerState(nil)
 
-	data, err := json.Marshal(ps)
+	gotJSON, err := json.Marshal(ps)
 	require.NoError(t, err)
 
-	require.JSONEq(t, `{
+	wantJSON := `{
 		"round_state":{
 			"height": "0",
 			"round": -1,
 			"step": 0,
 			"start_time": "0001-01-01T00:00:00Z",
 			"proposal": false,
+			"proposal_blob_part_set_header":
+				{"total":0, "hash":""},
+			"proposal_blob_parts": null,
 			"proposal_block_part_set_header":
 				{"total":0, "hash":""},
 			"proposal_block_parts": null,
@@ -1151,7 +1154,9 @@ func TestMarshalJSONPeerState(t *testing.T) {
 			"votes":"0",
 			"block_parts":"0",
 			"blob_parts":"0"}
-		}`, string(data))
+		}`
+
+	require.JSONEq(t, wantJSON, string(gotJSON))
 }
 
 func TestVoteMessageValidateBasic(t *testing.T) {

--- a/internal/consensus/types/peer_round_state.go
+++ b/internal/consensus/types/peer_round_state.go
@@ -24,7 +24,10 @@ type PeerRoundState struct {
 	Proposal                   bool                `json:"proposal"`
 	ProposalBlockPartSetHeader types.PartSetHeader `json:"proposal_block_part_set_header"`
 	// This bit array is length(# of block parts)
-	ProposalBlockParts *bits.BitArray `json:"proposal_block_parts"`
+	ProposalBlockParts        *bits.BitArray      `json:"proposal_block_parts"`
+	ProposalBlobPartSetHeader types.PartSetHeader `json:"proposal_blob_part_set_header"`
+	// This bit array is length(# of blob parts)
+	ProposalBlobParts *bits.BitArray `json:"proposal_blob_parts"`
 	// Proposal's POL round. -1 if none.
 	ProposalPOLRound int32 `json:"proposal_pol_round"`
 
@@ -52,7 +55,8 @@ func (prs PeerRoundState) String() string {
 func (prs PeerRoundState) StringIndented(indent string) string {
 	return fmt.Sprintf(`PeerRoundState{
 %s  %v/%v/%v @%v
-%s  Proposal %v -> %v
+%s  ProposalBlock %v -> %v
+%s  ProposalBlob %v -> %v
 %s  POL      %v (round %v)
 %s  Prevotes   %v
 %s  Precommits %v
@@ -61,6 +65,7 @@ func (prs PeerRoundState) StringIndented(indent string) string {
 %s}`,
 		indent, prs.Height, prs.Round, prs.Step, prs.StartTime,
 		indent, prs.ProposalBlockPartSetHeader, prs.ProposalBlockParts,
+		indent, prs.ProposalBlobPartSetHeader, prs.ProposalBlobParts,
 		indent, prs.ProposalPOL, prs.ProposalPOLRound,
 		indent, prs.Prevotes,
 		indent, prs.Precommits,


### PR DESCRIPTION
Part of the work of https://github.com/berachain/cometbft/pull/26.

### Context
The `PeerRoundState` type represents the known state of a peer. A CometBFT node maintains a `PeerRoundState` object in memory for each connected peer.

With the introduction of blobs, nodes must gossip them across the network. Since blobs are split into multiple smaller parts (#12), a node needs to track which blob parts each peer has already received. This prevents redundant transmissions, thus reducing unnecessary network messages.

### Changes
This PR adds blob-related fields to `PeerRoundState`. 